### PR TITLE
Add PipRail MCP to Community Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 
 ### Community Tools
 <!-- Add community-built tools here -->
+- [PipRail MCP](https://github.com/piprail/piprail) - An MCP server giving a self-hosted Letta agent a budget-bound, self-custody wallet to pay x402 "402 Payment Required" APIs across many chains.
 - Your tool here! - Submit a PR
 
 ### Development Tools


### PR DESCRIPTION
Adds **PipRail** to `### Community Tools`.

[PipRail](https://github.com/piprail/piprail) (`@piprail/mcp`) is a self-custody MCP server that gives a **self-hosted Letta agent** a budget-bound wallet to autonomously pay **x402** ("402 Payment Required") APIs across many chains — no facilitator, no fee. Wire it up with stdio MCP:

```python
client.mcp_servers.create(
    server_name="piprail",
    config={"mcp_server_type": "stdio", "command": "npx",
            "args": ["-y", "@piprail/mcp"], "env": {"PIPRAIL_PRIVATE_KEY": "0x..."}},
)
```

(stdio MCP is self-hosted/Docker Letta — hence the wording.) On npm + the official MCP Registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)